### PR TITLE
added params 'key', 'name', 'build_url_file', 'description_file'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,15 @@ No-op
 
 Update the status of a commit.
 
-Parameters:
+Parameters: *(items in bold are required)*
 
  * **`repo`** - Name of the git repo containing the SHA to be updated. This will come from a previous `get` on a `git` resource. Make sure to use the git directory name, not the name of the resource.
  * **`build_status`** - the state of the status. Must be one of `SUCCESSFUL`, `FAILED`, or `INPROGRESS` - case sensitive.
+ * `build_url_file` - Use the url given in file.
+ * `key` - Use the given key in build notification. If different notifications have the same key, they will stack.
+ * `name` - Use the given name in build notification. This will show up on bitbucket. For example "unit tests", "end to end tests"
+ * `description_file` - A path to a file containing a description of the build. For example: "7 tests have failed"
+
 
 
 ## Example

--- a/scripts/bitbucket.py
+++ b/scripts/bitbucket.py
@@ -109,21 +109,40 @@ if 'scripts.bitbucket' != __name__:
         err(json_pp(j))
         err("Notifying %s that build %s is in status: %s" %
             (post_url, os.environ["BUILD_NAME"], build_status))
+    if "key" in j["params"]:
+        key = j["params"]["key"]
+    else:
+        key = os.environ["BUILD_JOB_NAME"]
 
-    build_url = "{url}/pipelines/{pipeline}/jobs/{jobname}/builds/{buildname}".format(
-            url=os.environ['ATC_EXTERNAL_URL'],
-            pipeline=os.environ['BUILD_PIPELINE_NAME'],
-            jobname=os.environ['BUILD_JOB_NAME'],
-            buildname=os.environ['BUILD_NAME'],
-    )
+    if "name" in j["params"]:
+        name = j["params"]["name"]
+    else:
+        name = os.environ["BUILD_NAME"]
+
+    if "build_url_file" in j["params"]:
+        with open(os.path.join(sys.argv[1], j["params"]["build_url_file"]), "r") as fp:
+            build_url = fp.readlines()[0]
+    else:
+        build_url = "{url}/pipelines/{pipeline}/jobs/{jobname}/builds/{buildname}".format(
+                url=os.environ['ATC_EXTERNAL_URL'],
+                pipeline=os.environ['BUILD_PIPELINE_NAME'],
+                jobname=os.environ['BUILD_JOB_NAME'],
+                buildname=os.environ['BUILD_NAME'],
+        )
+
+    if "description_file" in j["params"]:
+        with open(os.path.join(sys.argv[1], j["params"]["description_file"]), "r") as fp:
+            description = fp.read()
+    else:
+        description = "Concourse build %s" % os.environ["BUILD_ID"]
 
     # https://developer.atlassian.com/bitbucket/server/docs/latest/how-tos/updating-build-status-for-commits.html
     js = {
         "state": build_status,
-        "key": os.environ["BUILD_JOB_NAME"],
-        "name": os.environ["BUILD_NAME"],
+        "key": key,
+        "name": name,
         "url": build_url,
-        "description": "Concourse build %s" % os.environ["BUILD_ID"]
+        "description": description
     }
 
     if debug:


### PR DESCRIPTION
Added 4 new params to allow the user to set all of these paremeters: https://confluence.atlassian.com/bitbucket/buildstatus-resource-779295267.html?_ga=1.10789814.386559380.1478448071

I wanted to be able to set the name and description that appeared on bitbucket builds more verbose. So that's why I added those two parameters.

I also wanted the build notifications to point to the url of the build that I just released so that's why build_url_file is added.

And I sent multiple notifications from one build and I didn't want them to stack, so that is why the key parameter is added.