### PR TITLE
Use Bitbucket Cloud V2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo is tied to the [associated Docker image](https://hub.docker.com/r/karu
 These items go in the `source` fields of the resource type. Bold items are required:
 
  * **`bitbucket_user`** - Login username of someone with rights to the repository being updated.
- * **`bitbucket_password`** - Password for the mentioned user. For Bitbucket Cloud this will need to be an [app password](https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html)
+ * **`bitbucket_password`** - Password for the mentioned user. For Bitbucket Cloud this will need to be an [app password](https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html) with permission to read from a repository and write to a repository.
  * `debug` - When True, dump the JSON documents sent and received for troubleshooting. (default: false)
  * `driver` - Are you using Bitbucket Cloud or Bitbucket Server. (default: Bitbucket Server)
  * `verify_ssl` - When False, ignore any HTTPS connection errors if generated. Useful if on an internal network. (default: True)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,18 @@ This repo is tied to the [associated Docker image](https://hub.docker.com/r/karu
 
 These items go in the `source` fields of the resource type. Bold items are required:
 
- * **`bitbucket_url`** - *base* URL of the bitbucket instance, including a trailing slash. (example: `https://bitbucket.mynetwork.com/`)
  * **`bitbucket_user`** - Login username of someone with rights to the repository being updated.
- * **`bitbucket_password`** - Password for the mentioned user
+ * **`bitbucket_password`** - Password for the mentioned user. For Bitbucket Cloud this will need to be an [app password](https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html)
  * `debug` - When True, dump the JSON documents sent and received for troubleshooting. (default: false)
+ * `driver` - Are you using Bitbucket Cloud or Bitbucket Server. (default: Bitbucket Server)
  * `verify_ssl` - When False, ignore any HTTPS connection errors if generated. Useful if on an internal network. (default: True)
 
+### `Bitbucket Cloud` Driver
+* **`owner`** - The owner of the repository, which will either be a username or team
+* **`repository_name`** - The name of the repository on Bitbucket Cloud
 
+### `Bitbucket Server` Driver
+* **`bitbucket_url`** - *base* URL of the bitbucket instance, including a trailing slash. (example: `https://bitbucket.mynetwork.com/`)
 ## Behavior
 
 

--- a/scripts/bitbucket.py
+++ b/scripts/bitbucket.py
@@ -107,8 +107,8 @@ if 'scripts.bitbucket' != __name__:
     if driver == 'Bitbucket Server':
         post_url = j['source']['bitbucket_url'] + 'rest/build-status/1.0/commits/' + commit_sha
     elif driver == 'Bitbucket Cloud':
-        owner = j['source']['owner']
-        repository_name = j['source']['repository_name']
+        owner = j['source'].get('owner', username)
+        repository_name = j['source'].get('repository_name', j['params']['repo'])
         post_url = 'https://api.bitbucket.org/2.0/repositories/' + owner + '/' + repository_name + '/commit/' + commit_sha + '/statuses/build'
     else:
         err("Invalid driver, must be: Bitbucket Server or Bitbucket Cloud")


### PR DESCRIPTION
I couldn't get this to work with [Bitbucket Cloud][2] and so change it to use the [V2 API][1]. This required an extra couple parameters.

Also `status_js` occasionally has a value of `None` and so [line 154][3] fails.

[1]: https://confluence.atlassian.com/bitbucket/buildstatus-resource-779295267.html?_ga=1.228759580.1655652342.1484036169
[2]: https://bitbucket.org
[3]: https://github.com/Fydon/concourse-resource-bitbucket/blob/feature/AddBitbucketCloud/scripts/bitbucket.py#L154